### PR TITLE
Fixed the tooltip position jumping all over the place, when custom scale was applied.

### DIFF
--- a/src/main/java/dev/g1ax/mixin/GuiGraphicsMixin.java
+++ b/src/main/java/dev/g1ax/mixin/GuiGraphicsMixin.java
@@ -25,7 +25,6 @@ import java.util.List;
 @Mixin(GuiGraphics.class)
 public class GuiGraphicsMixin {
     @Shadow @Final private Matrix3x2fStack pose;
-    @Unique Vector2ic v;
     @Unique private int frameX, frameY;
 
     @WrapOperation(method = "renderTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/inventory/tooltip/ClientTooltipPositioner;positionTooltip(IIIIII)Lorg/joml/Vector2ic;"))
@@ -34,8 +33,7 @@ public class GuiGraphicsMixin {
         if (!(Minecraft.getInstance().screen instanceof AbstractContainerScreen) || scale == 1.0F) {
             return original.call(instance, width, height, mouseX, mouseY, i, j);
         }
-        v = original.call(instance, (int) (width / scale), (int) (height / scale), mouseX, mouseY, (int) (i / scale), (int) (j / scale));
-        return calculatePos(v, (int) (i * scale), (int) (j * scale), (int) (width / scale), (int) (height / scale));
+        return calculatePos((int) (i * scale), (int) (j * scale), width, height, mouseX, mouseY);
     }
 
     @Inject(method = "renderTooltip", at = @At(value = "INVOKE", target = "Lorg/joml/Matrix3x2fStack;pushMatrix()Lorg/joml/Matrix3x2fStack;", shift = At.Shift.AFTER))
@@ -48,12 +46,12 @@ public class GuiGraphicsMixin {
     }
 
     @Unique
-    public Vector2ic calculatePos(Vector2ic v, int tw, int th, int sw, int sh) {
-        frameX = v.x();
-        frameY = v.y();
+    public Vector2ic calculatePos(int tw, int th, int sw, int sh, int mouseX, int mouseY) {
+        frameX = mouseX + 12;
+        frameY = mouseY - 12;
 
-        if (tw > sw) frameX = frameX - v.x() + 4;
-        if (th > sh) frameY = frameY - v.y() + 4;
+        if (frameX + tw > sw) frameX = Math.max(mouseX - 12 - tw, 4);
+        if (frameY + th + 3 > sh) frameY =  sh - th - 3;
 
         return new Vector2i(0, 0);
     }


### PR DESCRIPTION
Hey, when testing your mod I noticed that after changing the tooltip scale, it would position itself in the wrong place often off-screen. So I looked at how vanilla calculates the tooltip position and basically copied it over. 

My changes include:
1. Rewriting `calculatePos` so it matches vanilla 1.21.11 behavior.
2. Removing the now unused variable `v`.

<details>
  <summary>View Vanilla Reference (DefaultTooltipPositioner.java)</summary>
  
  ```java
  // Source code is decompiled from a .class file using FernFlower decompiler (from Intellij IDEA).
  package net.minecraft.client.gui.screens.inventory.tooltip;
  
  import net.fabricmc.api.EnvType;
  import net.fabricmc.api.Environment;
  import org.joml.Vector2i;
  import org.joml.Vector2ic;
  
  @Environment(EnvType.CLIENT)
  public class DefaultTooltipPositioner implements ClientTooltipPositioner {
     public static final ClientTooltipPositioner INSTANCE = new DefaultTooltipPositioner();
  
     private DefaultTooltipPositioner() {
     }
  
     public Vector2ic positionTooltip(int i, int j, int k, int l, int m, int n) {
        Vector2i vector2i = (new Vector2i(k, l)).add(12, -12);
        this.positionTooltip(i, j, vector2i, m, n);
        return vector2i;
     }
  
     private void positionTooltip(int i, int j, Vector2i vector2i, int k, int l) {
        if (vector2i.x + k > i) {
           vector2i.x = Math.max(vector2i.x - 24 - k, 4);
        }
  
        int m = l + 3;
        if (vector2i.y + m > j) {
           vector2i.y = j - m;
        }
  
     }
  }
 ```
</details>